### PR TITLE
Update to newer kwiver (release)

### DIFF
--- a/plugins/core/CMakeLists.txt
+++ b/plugins/core/CMakeLists.txt
@@ -26,7 +26,7 @@ kwiver_add_library( viame_core
   )
 
 target_link_libraries( viame_core
-  PUBLIC               vital_algo
+  PUBLIC               kwiver_algo
   )
 
 algorithms_create_plugin( viame_core

--- a/plugins/hello_world/CMakeLists.txt
+++ b/plugins/hello_world/CMakeLists.txt
@@ -27,7 +27,7 @@ kwiver_add_library( viame_hello_world
   )
 
 target_link_libraries( viame_hello_world
-  PUBLIC               vital_algo
+  PUBLIC               kwiver_algo
   )
 
 algorithms_create_plugin( viame_hello_world


### PR DESCRIPTION
Update kwiver - previous version doesn't build on Windows. Then update viame for changed library names.