### PR TITLE
Fixed issue with installing smqtk when a virtualenv is enabled

### DIFF
--- a/cmake/add_project_smqtk.cmake
+++ b/cmake/add_project_smqtk.cmake
@@ -9,29 +9,84 @@
 
 set( VIAME_PROJECT_LIST ${VIAME_PROJECT_LIST} smqtk )
 
+
+###
+# Private helper function to execute `python -c "<cmd>"`
+#
+# Runs a python command and populates an outvar with the result of stdout.
+# Be careful of indentation if `cmd` is multiline.
+#
+function(_pycmd outvar cmd)
+  execute_process(
+    COMMAND "${PYTHON_EXECUTABLE}" -c "${cmd}"
+    RESULT_VARIABLE _exitcode
+    OUTPUT_VARIABLE _output)
+  if(NOT ${_exitcode} EQUAL 0)
+    message(ERROR "Failed when running python code: \"\"\"
+${cmd}\"\"\"")
+    message(FATAL_ERROR "Python command failed with error code: ${_exitcode}")
+  endif()
+  # Remove supurflous newlines (artifacts of print)
+  string(STRIP "${_output}" _output)
+  set(${outvar} "${_output}" PARENT_SCOPE)
+endfunction()
+
+# Copy logic for getting site packages from kwiver
+_pycmd(python_site_packages "\
+from distutils import sysconfig
+print(sysconfig.get_python_lib(prefix=''))
+")
+message(STATUS "python_site_packages = ${python_site_packages}")
+get_filename_component(python_sitename ${python_site_packages} NAME)
+
+_pycmd(python_pip_version "import pip; print(pip.__version__)")
+
 if( WIN32 )
   message( FATAL_ERROR "SMQTK not yet supported on WIN32" )
 else()
-  if( VIAME_SYMLINK_PYTHON )
-    set( SMQTK_PIP_CMD
-      pip install --user -e .[postgres] )
-  else()
-    # This is only required for no symlink install without a -e with older
-    # versions of pip, for never versions the above command works with no -e
-    set( SMQTK_PIP_CMD
-      pip install --user file://${VIAME_PACKAGES_DIR}/smqtk\#egg=smqtk[postgres] )
-  endif()
+
   set( PYTHON_BASEPATH
     ${VIAME_BUILD_INSTALL_PREFIX}/lib/python${PYTHON_VERSION}${PYTHON_ABIFLAGS} )
-  set( CUSTOM_PYTHONPATH
-    ${PYTHON_BASEPATH}/site-packages:${PYTHON_BASEPATH}/dist-packages:$ENV{PYTHONPATH} )
-  set( CUSTOM_PATH
-    ${VIAME_BUILD_INSTALL_PREFIX}/bin:$ENV{PATH} )
-  set( SMQTK_PYTHON_INSTALL
-    ${CMAKE_COMMAND} -E env PYTHONPATH=${CUSTOM_PYTHONPATH}
-                        env PATH=${CUSTOM_PATH}
-                        env PYTHONUSERBASE=${VIAME_BUILD_INSTALL_PREFIX}
-      ${PYTHON_EXECUTABLE} -m ${SMQTK_PIP_CMD} )
+  set( CUSTOM_SITEPACKAGES ${PYTHON_BASEPATH}/${python_sitename})
+  set( CUSTOM_PYTHONPATH ${CUSTOM_SITEPACKAGES}:$ENV{PYTHONPATH} )
+  set( CUSTOM_PATH ${VIAME_BUILD_INSTALL_PREFIX}/bin:$ENV{PATH} )
+
+  # NOTES: In more recent pip versions, this step is much easier
+  # https://pip.pypa.io/en/stable/news/
+  # Useful commands and the versions they were added in:
+  # version 0.1.4: --install-option
+  # version 1.1.0: --target
+  # version 1.3.0: --root
+  # version 7.0.0: --prefix
+  # version ~8.0.0: fixes issues with no -e and "extras_require"
+
+  if (python_pip_version VERSION_LESS 9.0.0)
+    if( VIAME_SYMLINK_PYTHON )
+      set( SMQTK_PIP_CMD
+        pip install --user -e .[postgres] )
+    else()
+      # This is only required for no symlink install without a -e with older
+      # versions of pip, for never versions the above command works with no -e
+      set( SMQTK_PIP_CMD
+        pip install --user file://${VIAME_PACKAGES_DIR}/smqtk\#egg=smqtk[postgres] )
+    endif()
+    set( SMQTK_PYTHON_INSTALL
+      ${CMAKE_COMMAND} -E env PYTHONPATH=${CUSTOM_PYTHONPATH}
+                          env PATH=${CUSTOM_PATH}
+                          env PYTHONUSERBASE=${VIAME_BUILD_INSTALL_PREFIX}
+        ${PYTHON_EXECUTABLE} -m ${SMQTK_PIP_CMD} )
+  else()
+    # If we are using virtualenvs then a more up to date pip is necessary
+    if( VIAME_SYMLINK_PYTHON )
+      set( SMQTK_PIP_CMD pip install "--prefix=${VIAME_BUILD_INSTALL_PREFIX}" -e .[postgres])
+    else()
+      set( SMQTK_PIP_CMD pip install "--prefix=${VIAME_BUILD_INSTALL_PREFIX}" .[postgres])
+    endif()
+    set( SMQTK_PYTHON_INSTALL
+      ${CMAKE_COMMAND} -E env PYTHONPATH=${CUSTOM_PYTHONPATH}
+                          env PATH=${CUSTOM_PATH}
+        ${PYTHON_EXECUTABLE} -m ${SMQTK_PIP_CMD} )
+  endif()
 endif()
 
 ExternalProject_Add( smqtk

--- a/cmake/add_project_smqtk.cmake
+++ b/cmake/add_project_smqtk.cmake
@@ -14,7 +14,7 @@ if( WIN32 )
 else()
 
   # Logic for getting site packages is copied from kwiver
-  # (but it uses a new pycmd function that handles indentation -- ooohh. aahh.)
+  # (but it uses a new pycmd function that handles indentation)
   pycmd(python_site_packages "
     from distutils import sysconfig
     print(sysconfig.get_python_lib(prefix=''))

--- a/cmake/add_project_smqtk.cmake
+++ b/cmake/add_project_smqtk.cmake
@@ -9,41 +9,20 @@
 
 set( VIAME_PROJECT_LIST ${VIAME_PROJECT_LIST} smqtk )
 
-
-###
-# Private helper function to execute `python -c "<cmd>"`
-#
-# Runs a python command and populates an outvar with the result of stdout.
-# Be careful of indentation if `cmd` is multiline.
-#
-function(_pycmd outvar cmd)
-  execute_process(
-    COMMAND "${PYTHON_EXECUTABLE}" -c "${cmd}"
-    RESULT_VARIABLE _exitcode
-    OUTPUT_VARIABLE _output)
-  if(NOT ${_exitcode} EQUAL 0)
-    message(ERROR "Failed when running python code: \"\"\"
-${cmd}\"\"\"")
-    message(FATAL_ERROR "Python command failed with error code: ${_exitcode}")
-  endif()
-  # Remove supurflous newlines (artifacts of print)
-  string(STRIP "${_output}" _output)
-  set(${outvar} "${_output}" PARENT_SCOPE)
-endfunction()
-
-# Copy logic for getting site packages from kwiver
-_pycmd(python_site_packages "\
-from distutils import sysconfig
-print(sysconfig.get_python_lib(prefix=''))
-")
-message(STATUS "python_site_packages = ${python_site_packages}")
-get_filename_component(python_sitename ${python_site_packages} NAME)
-
-_pycmd(python_pip_version "import pip; print(pip.__version__)")
-
 if( WIN32 )
   message( FATAL_ERROR "SMQTK not yet supported on WIN32" )
 else()
+
+  # Logic for getting site packages is copied from kwiver
+  # (but it uses a new pycmd function that handles indentation -- ooohh. aahh.)
+  pycmd(python_site_packages "
+    from distutils import sysconfig
+    print(sysconfig.get_python_lib(prefix=''))
+  ")
+  message(STATUS "python_site_packages = ${python_site_packages}")
+  get_filename_component(python_sitename ${python_site_packages} NAME)
+
+  pycmd(python_pip_version "import pip; print(pip.__version__)")
 
   set( PYTHON_BASEPATH
     ${VIAME_BUILD_INSTALL_PREFIX}/lib/python${PYTHON_VERSION}${PYTHON_ABIFLAGS} )

--- a/cmake/common_macros.cmake
+++ b/cmake/common_macros.cmake
@@ -58,3 +58,76 @@ function( RemoveDir _inDir )
 endfunction()
 
 
+###
+# Removes common indentation from a block of text to produce code suitable for
+# setting to `python -c`, or using with pycmd. This allows multiline code to be
+# nested nicely in the surrounding code structure.
+#
+# This function respsects PYTHON_EXECUTABLE if it defined, otherwise it uses
+# `python` and hopes for the best. An error will be thrown if it is not found.
+#
+# Args:
+#     outvar : variable that will hold the stdout of the python command
+#     text   : text to remove indentation from
+#
+function(dedent outvar text)
+  # Use PYTHON_EXECUTABLE if it is defined, otherwise default to python
+  if ("${PYTHON_EXECUTABLE}" STREQUAL "")
+    set(_python_exe "python")
+  else()
+    set(_python_exe "${PYTHON_EXECUTABLE}")
+  endif()
+  set(_fixup_cmd "import sys; from textwrap import dedent; print(dedent(sys.stdin.read()))")
+  # Use echo to pipe the text to python's stdinput. This prevents us from
+  # needing to worry about any sort of special escaping.
+  execute_process(
+    COMMAND echo "${text}"
+    COMMAND "${_python_exe}" -c "${_fixup_cmd}"
+    RESULT_VARIABLE _dedent_exitcode
+    OUTPUT_VARIABLE _dedent_text)
+  if(NOT ${_dedent_exitcode} EQUAL 0)
+    message(ERROR " Failed to remove indentation from: \n\"\"\"\n${text}\n\"\"\"
+    Python dedent failed with error code: ${_dedent_exitcode}")
+    message(FATAL_ERROR " Python dedent failed with error code: ${_dedent_exitcode}")
+  endif()
+  # Remove supurflous newlines (artifacts of print)
+  string(STRIP "${_dedent_text}" _dedent_text)
+  set(${outvar} "${_dedent_text}" PARENT_SCOPE)
+endfunction()
+
+
+###
+# Helper function to run `python -c "<cmd>"` and capture the results of stdout
+#
+# Runs a python command and populates an outvar with the result of stdout.
+# Common indentation in the text of `cmd` is removed before the command is
+# executed, so the caller does not need to worry about indentation issues.
+#
+# This function respsects PYTHON_EXECUTABLE if it defined, otherwise it uses
+# `python` and hopes for the best. An error will be thrown if it is not found.
+#
+# Args:
+#     outvar : variable that will hold the stdout of the python command
+#     cmd    : text representing a (possibly multiline) block of python code
+#
+function(pycmd outvar cmd)
+  dedent(_dedent_cmd "${cmd}")
+  # Use PYTHON_EXECUTABLE if it is defined, otherwise default to python
+  if ("${PYTHON_EXECUTABLE}" STREQUAL "")
+    set(_python_exe "python")
+  else()
+    set(_python_exe "${PYTHON_EXECUTABLE}")
+  endif()
+  # run the actual command
+  execute_process(
+    COMMAND "${_python_exe}" -c "${_dedent_cmd}"
+    RESULT_VARIABLE _exitcode
+    OUTPUT_VARIABLE _output)
+  if(NOT ${_exitcode} EQUAL 0)
+    message(ERROR " Failed when running python code: \"\"\"\n${_dedent_cmd}\n\"\"\"")
+    message(FATAL_ERROR " Python command failed with error code: ${_exitcode}")
+  endif()
+  # Remove supurflous newlines (artifacts of print)
+  string(STRIP "${_output}" _output)
+  set(${outvar} "${_output}" PARENT_SCOPE)
+endfunction()


### PR DESCRIPTION
The pip `--user` option doesn't work if you use a python virtualenv. 

While I did find a workaround for old versions of pip, they were extremely cumbersome and required me to preinstall `psycopg2` before I tried to install `smqtk`. 

Thinking about it, I figured any person using a virtualenv is probably going to have a more recent version of pip. Thus, I wrote a function that checks the version of pip and if its modern (`>=9.0.0`). If its not it uses the `--user` + environment variable method to install the package to a specific directory. Any virtualenvs users will still fail here, but hopefully they will just `pip install pip -U` and be on their way.  

It the pip version is `>=9.0.0`, then the smqtk install command uses the much more concise and standard `--prefix` synatax. This version also uses the simplified extra_requires syntax as well without needing the `file://` stuff.    

While I was here I also put in code to determine and use the correct version of site-packages / dist-packages when setting up the PYTHONPATH.  This uses some copy/pasted logic from kwiver (although I did use an improved version of my pycmd function.)