### PR TITLE
Fix our smqtk build for windows

### DIFF
--- a/cmake/add_project_smqtk.cmake
+++ b/cmake/add_project_smqtk.cmake
@@ -9,9 +9,6 @@
 
 set( VIAME_PROJECT_LIST ${VIAME_PROJECT_LIST} smqtk )
 
-if( WIN32 )
-  message( FATAL_ERROR "SMQTK not yet supported on WIN32" )
-else()
   if( VIAME_SYMLINK_PYTHON )
     set( SMQTK_PIP_CMD
       pip install --user -e .[postgres] )
@@ -24,15 +21,14 @@ else()
   set( PYTHON_BASEPATH
     ${VIAME_BUILD_INSTALL_PREFIX}/lib/python${PYTHON_VERSION}${PYTHON_ABIFLAGS} )
   set( CUSTOM_PYTHONPATH
-    ${PYTHON_BASEPATH}/site-packages:${PYTHON_BASEPATH}/dist-packages:$ENV{PYTHONPATH} )
+    ${PYTHON_BASEPATH}/site-packages:${PYTHON_BASEPATH}/dist-packages )
   set( CUSTOM_PATH
-    ${VIAME_BUILD_INSTALL_PREFIX}/bin:$ENV{PATH} )
+    ${VIAME_BUILD_INSTALL_PREFIX}/bin )
   set( SMQTK_PYTHON_INSTALL
     ${CMAKE_COMMAND} -E env PYTHONPATH=${CUSTOM_PYTHONPATH}
-                        env PATH=${CUSTOM_PATH}
-                        env PYTHONUSERBASE=${VIAME_BUILD_INSTALL_PREFIX}
+                        PATH=${CUSTOM_PATH}
+                        PYTHONUSERBASE=${VIAME_BUILD_INSTALL_PREFIX}
       ${PYTHON_EXECUTABLE} -m ${SMQTK_PIP_CMD} )
-endif()
 
 ExternalProject_Add( smqtk
   DEPENDS fletch

--- a/cmake/add_project_smqtk.cmake
+++ b/cmake/add_project_smqtk.cmake
@@ -9,26 +9,26 @@
 
 set( VIAME_PROJECT_LIST ${VIAME_PROJECT_LIST} smqtk )
 
-  if( VIAME_SYMLINK_PYTHON )
-    set( SMQTK_PIP_CMD
-      pip install --user -e .[postgres] )
-  else()
-    # This is only required for no symlink install without a -e with older
-    # versions of pip, for never versions the above command works with no -e
-    set( SMQTK_PIP_CMD
-      pip install --user file://${VIAME_PACKAGES_DIR}/smqtk\#egg=smqtk[postgres] )
-  endif()
-  set( PYTHON_BASEPATH
-    ${VIAME_BUILD_INSTALL_PREFIX}/lib/python${PYTHON_VERSION}${PYTHON_ABIFLAGS} )
-  set( CUSTOM_PYTHONPATH
-    ${PYTHON_BASEPATH}/site-packages:${PYTHON_BASEPATH}/dist-packages )
-  set( CUSTOM_PATH
-    ${VIAME_BUILD_INSTALL_PREFIX}/bin )
-  set( SMQTK_PYTHON_INSTALL
-    ${CMAKE_COMMAND} -E env PYTHONPATH=${CUSTOM_PYTHONPATH}
-                        PATH=${CUSTOM_PATH}
-                        PYTHONUSERBASE=${VIAME_BUILD_INSTALL_PREFIX}
-      ${PYTHON_EXECUTABLE} -m ${SMQTK_PIP_CMD} )
+if( VIAME_SYMLINK_PYTHON )
+  set( SMQTK_PIP_CMD
+    pip install --user -e .[postgres] )
+else()
+  # This is only required for no symlink install without a -e with older
+  # versions of pip, for never versions the above command works with no -e
+  set( SMQTK_PIP_CMD
+    pip install --user file://${VIAME_PACKAGES_DIR}/smqtk\#egg=smqtk[postgres] )
+endif()
+set( PYTHON_BASEPATH
+  ${VIAME_BUILD_INSTALL_PREFIX}/lib/python${PYTHON_VERSION}${PYTHON_ABIFLAGS} )
+set( CUSTOM_PYTHONPATH
+  ${PYTHON_BASEPATH}/site-packages:${PYTHON_BASEPATH}/dist-packages )
+set( CUSTOM_PATH
+  ${VIAME_BUILD_INSTALL_PREFIX}/bin )
+set( SMQTK_PYTHON_INSTALL
+  ${CMAKE_COMMAND} -E env PYTHONPATH=${CUSTOM_PYTHONPATH}
+                      PATH=${CUSTOM_PATH}
+                      PYTHONUSERBASE=${VIAME_BUILD_INSTALL_PREFIX}
+    ${PYTHON_EXECUTABLE} -m ${SMQTK_PIP_CMD} )
 
 ExternalProject_Add( smqtk
   DEPENDS fletch


### PR DESCRIPTION
Using the default env paths breaks Windows. We could also sanitize the path, but this is quicker and easier for our deadline. We also need to get rid of those extra "env" flags, proper usage is "cmake -E env var1=value1 var2=value2 var3=value3".