### PR TITLE
WIP: Parallel ingest

### DIFF
--- a/configs/ingest_video.py
+++ b/configs/ingest_video.py
@@ -298,19 +298,17 @@ if __name__ == "__main__" :
   if args.init_db:
     database_tool.init()
 
-  # Identify all videos to process
-  video_list = []
-
   if process_data:
 
+    # Identify all videos to process
     if len( args.input_list ) > 0:
-      video_list.append( args.input_list )
+      video_list = [args.input_list]
       is_image_list = True
     elif len( args.input_dir ) > 0:
       video_list = list_files_in_dir( args.input_dir )
       is_image_list = False
     else:
-      video_list.append( args.input_video )
+      video_list = [args.input_video]
       is_image_list = False
 
     if len( video_list ) == 0:

--- a/configs/ingest_video.py
+++ b/configs/ingest_video.py
@@ -143,10 +143,13 @@ def remove_quotes( input_str ):
   return input_str.replace( "\"", "" )
 
 # Process a single video
-def process_video_kwiver( input_name, options, is_image_list=False, base_ovrd='' ):
+def process_video_kwiver( input_name, options, is_image_list=False, base_ovrd='', gpu=None ):
 
   sys.stdout.write( 'Processing: ' + input_name + "... " )
   sys.stdout.flush()
+
+  if gpu is None:
+    gpu = 0
 
   # Get video name without extension and full path
   if len( base_ovrd ) > 0:
@@ -178,9 +181,9 @@ def process_video_kwiver( input_name, options, is_image_list=False, base_ovrd=''
   # Process command, possibly with logging
   if len( args.log_dir ) > 0 and not args.debug:
     with get_log_output_files(args.log_dir + '/' + basename) as kwargs:
-      res = execute_command(command, gpu=0, **kwargs)
+      res = execute_command(command, gpu=gpu, **kwargs)
   else:
-    res = execute_command(command, gpu=0)
+    res = execute_command(command, gpu=gpu)
 
   if res == 0:
     print( 'Success' )
@@ -316,7 +319,7 @@ if __name__ == "__main__" :
     # Process videos
     for video_name in video_list:
       if os.path.exists( video_name ) and os.path.isfile( video_name ):
-        process_video_kwiver( video_name, args, is_image_list )
+        process_video_kwiver( video_name, args, is_image_list, gpu=0 )
       else:
         print( "Skipping " + video_name )
 

--- a/configs/ingest_video.py
+++ b/configs/ingest_video.py
@@ -145,11 +145,11 @@ def remove_quotes( input_str ):
 # Process a single video
 def process_video_kwiver( input_name, options, is_image_list=False, base_ovrd='', gpu=None ):
 
-  sys.stdout.write( 'Processing: ' + input_name + "... " )
-  sys.stdout.flush()
-
   if gpu is None:
     gpu = 0
+
+  sys.stdout.write( 'Processing: {} on GPU {}... '.format(os.path.basename(input_name), gpu) )
+  sys.stdout.flush()
 
   # Get video name without extension and full path
   if len( base_ovrd ) > 0:
@@ -186,10 +186,11 @@ def process_video_kwiver( input_name, options, is_image_list=False, base_ovrd=''
     res = execute_command(command, gpu=gpu)
 
   if res == 0:
-    print( 'Success' )
+    print( 'Success ({})'.format(gpu) )
   else:
-    print( 'Failure' )
-    exit_with_error( '\nIngest failed, check database/Log files, terminating.\n' )
+    print( 'Failure ({})'.format(gpu) )
+    exit_with_error( '\nIngest failed, check database/Log files for {}, terminating.\n'
+                     .format(os.path.basename(input_name)) )
 
 # Plot settings strings
 def plot_settings_list( basename ):


### PR DESCRIPTION
This branch is based on top of that in #61. It offers parallelization of `config/ingest_video.py`'s ingest by running one pipeline per GPU. This is accessible through a new option `-g/--gpu-count` that will use the provided number of GPUs.

Videos are dynamically allocated to GPUs by means of a queue. Image set inputs are also split between GPUs, but statically.

The `CUDA_VISIBLE_DEVICES` environment variable is used to control what GPU is used by the pipelines. I tried but ultimately decided against doing this by setting the corresponding pipeline process parameters because of a) the non-uniformity of the parameter names to change or another clean way to parameterize the pipelines and b) the fact that the PyTorch ResNet feature extractor doesn't completely respect the `gpu_list` config option (issue #63).

**TODO:**
- [ ] Test functionality on video input