### PR TITLE
Switch deep learning model training support to YOLOv3

### DIFF
--- a/configs/CMakeLists.txt
+++ b/configs/CMakeLists.txt
@@ -49,6 +49,12 @@ if( VIAME_DOWNLOAD_MODELS )
       ${VIAME_DOWNLOAD_DIR}/models-yolo_v2_seed_model-v1.0.0.tar.gz
       ${CMAKE_CURRENT_SOURCE_DIR}/pipelines )
 
+    DownloadAndExtract(
+      https://data.kitware.com/api/v1/item/5c115d918d777f2179e5ae9a/download
+      b8783e8d95ba7346a09137906f32406c
+      ${VIAME_DOWNLOAD_DIR}/models-yolo_v3_seed_model-v1.0.0.tar.gz
+      ${CMAKE_CURRENT_SOURCE_DIR}/pipelines )
+
     if( VIAME_DOWNLOAD_MODELS-HABCAM )
       DownloadAndExtract(
         https://data.kitware.com/api/v1/item/5b5e27cc8d777f06857c17c2/download

--- a/configs/pipelines/train_yolo_544.viame_csv.conf
+++ b/configs/pipelines/train_yolo_544.viame_csv.conf
@@ -28,10 +28,10 @@ detector_trainer:type = darknet
 detector_trainer:darknet:gpu_index = 0
 
 #  Name of network config file.
-relativepath detector_trainer:darknet:net_config = models/yolo_v2_train.cfg
+relativepath detector_trainer:darknet:net_config = models/yolo_v3_train.cfg
 
 #  Seed weights file.
-relativepath detector_trainer:darknet:seed_weights = models/yolo_v2_seed.wt
+relativepath detector_trainer:darknet:seed_weights = models/yolo_v3_seed.wt
 
 # Image reader parameters
 detector_trainer:darknet:image_reader:type = vxl

--- a/configs/pipelines/train_yolo_704.habcam.conf
+++ b/configs/pipelines/train_yolo_704.habcam.conf
@@ -28,10 +28,10 @@ detector_trainer:type = darknet
 detector_trainer:darknet:gpu_index = 0
 
 #  Name of network config file.
-relativepath detector_trainer:darknet:net_config = models/yolo_v2_train.cfg
+relativepath detector_trainer:darknet:net_config = models/yolo_v3_train.cfg
 
 #  Seed weights file.
-relativepath detector_trainer:darknet:seed_weights = models/yolo_v2_seed.wt
+relativepath detector_trainer:darknet:seed_weights = models/yolo_v3_seed.wt
 
 # Image reader parameters
 detector_trainer:darknet:image_reader:type = vxl

--- a/configs/pipelines/train_yolo_704.kw18.conf
+++ b/configs/pipelines/train_yolo_704.kw18.conf
@@ -28,10 +28,10 @@ detector_trainer:type = darknet
 detector_trainer:darknet:gpu_index = 0
 
 #  Name of network config file.
-relativepath detector_trainer:darknet:net_config = models/yolo_v2_train.cfg
+relativepath detector_trainer:darknet:net_config = models/yolo_v3_train.cfg
 
 #  Seed weights file.
-relativepath detector_trainer:darknet:seed_weights = models/yolo_v2_seed.wt
+relativepath detector_trainer:darknet:seed_weights = models/yolo_v3_seed.wt
 
 # Image reader parameters
 detector_trainer:darknet:image_reader:type = vxl

--- a/configs/pipelines/train_yolo_704.viame_csv.conf
+++ b/configs/pipelines/train_yolo_704.viame_csv.conf
@@ -28,10 +28,10 @@ detector_trainer:type = darknet
 detector_trainer:darknet:gpu_index = 0
 
 #  Name of network config file.
-relativepath detector_trainer:darknet:net_config = models/yolo_v2_train.cfg
+relativepath detector_trainer:darknet:net_config = models/yolo_v3_train.cfg
 
 #  Seed weights file.
-relativepath detector_trainer:darknet:seed_weights = models/yolo_v2_seed.wt
+relativepath detector_trainer:darknet:seed_weights = models/yolo_v3_seed.wt
 
 # Image reader parameters
 detector_trainer:darknet:image_reader:type = vxl

--- a/configs/pipelines/train_yolo_960.habcam.conf
+++ b/configs/pipelines/train_yolo_960.habcam.conf
@@ -28,10 +28,10 @@ detector_trainer:type = darknet
 detector_trainer:darknet:gpu_index = 0
 
 #  Name of network config file.
-relativepath detector_trainer:darknet:net_config = models/yolo_v2_train.cfg
+relativepath detector_trainer:darknet:net_config = models/yolo_v3_train.cfg
 
 #  Seed weights file.
-relativepath detector_trainer:darknet:seed_weights = models/yolo_v2_seed.wt
+relativepath detector_trainer:darknet:seed_weights = models/yolo_v3_seed.wt
 
 # Image reader parameters
 detector_trainer:darknet:image_reader:type = vxl

--- a/configs/pipelines/train_yolo_960.viame_csv.conf
+++ b/configs/pipelines/train_yolo_960.viame_csv.conf
@@ -28,10 +28,10 @@ detector_trainer:type = darknet
 detector_trainer:darknet:gpu_index = 0
 
 #  Name of network config file.
-relativepath detector_trainer:darknet:net_config = models/yolo_v2_train.cfg
+relativepath detector_trainer:darknet:net_config = models/yolo_v3_train.cfg
 
 #  Seed weights file.
-relativepath detector_trainer:darknet:seed_weights = models/yolo_v2_seed.wt
+relativepath detector_trainer:darknet:seed_weights = models/yolo_v3_seed.wt
 
 # Image reader parameters
 detector_trainer:darknet:image_reader:type = vxl


### PR DESCRIPTION
This PR, together with changes in the KWIVER trainer, changes the deep learning model training to create a YOLOv3 model by default, replacing YOLOv2.

Practically, this adds another archive with model weights and configuration in it to be downloaded with the other YOLO models, and updates the configuration files for the training tool to reference the new model.

The KWIVER changes are in my fork's [`train_yolov3` branch](https://github.com/neal-siekierski/kwiver/tree/train_yolov3). Unless they're added somewhere in the main repository, they'll need to be fetched manually, since `git submodule update` won't find them.

Using YOLOv2 is still possible, but now requires a line like `detector_trainer:darknet:model_type = yolov2` in the configuration files. I've opted to switch the default from YOLOv2 to YOLOv3 as part of the KWIVER change, but it may be cleaner to split that out instead.